### PR TITLE
7 DCAT jsonld serialization

### DIFF
--- a/dcat/models.py
+++ b/dcat/models.py
@@ -32,9 +32,17 @@ class Agent(models.Model):
     )
 
     # Optional properties
+    # TODO: mbox is not defined in DCAT
     mbox = models.EmailField(
         blank=True, null=True, help_text="An email address of the Agent."
     )
+
+    def to_dcat(self):
+        result = dict()
+        result['foaf:name'] = self.name
+        if self.type:
+            result['@type'] = self.type
+        return result
 
     def __str__(self):
         return self.name
@@ -68,6 +76,13 @@ class Catalog(models.Model):
     homepage = models.URLField(
         blank=True, help_text="A web page that acts as the main page for the Catalogue."
     )
+
+    def to_dcat(self):
+        result = dict()
+        result['dct:title'] = self.title
+        result['dct:description'] = self.description
+        result['dct:publisher'] = self.publisher.to_dcat()
+        return result
 
     def __str__(self):
         return self.title

--- a/dcat/models.py
+++ b/dcat/models.py
@@ -37,7 +37,7 @@ class Agent(models.Model):
         blank=True, null=True, help_text="An email address of the Agent."
     )
 
-    def to_dcat(self):
+    def to_jsonld(self):
         result = dict()
         result['foaf:name'] = self.name
         if self.type:
@@ -77,16 +77,16 @@ class Catalog(models.Model):
         blank=True, help_text="A web page that acts as the main page for the Catalogue."
     )
 
-    def to_dcat(self):
+    def to_jsonld(self):
         result = dict()
         result['@type'] = 'dcat:Catalog'
         result['dct:title'] = self.title
         result['dct:description'] = self.description
-        result['dct:publisher'] = self.publisher.to_dcat()
+        result['dct:publisher'] = self.publisher.to_jsonld()
         if self.homepage:
             result['foaf:homepage'] = {'@type': 'foaf:Document', 'foaf:Document': self.homepage}
 
-        result['dcat:dataset'] = [dataset.to_dcat() for dataset in self.dataset_set.all()]
+        result['dcat:dataset'] = [dataset.to_jsonld() for dataset in self.dataset_set.all()]
 
         return result
 
@@ -146,7 +146,7 @@ class Dataset(models.Model):
         help_text="A web page that provides access to the Dataset, its Distributions and/or additional information. It is intended to point to a landing page at the original data provider, not to a page on a site of a third party, such as an aggregator.",
     )
 
-    def to_dcat(self):
+    def to_jsonld(self):
         result = dict()
         result['dct:title'] = self.title
         if self.description:

--- a/dcat/models.py
+++ b/dcat/models.py
@@ -79,9 +79,12 @@ class Catalog(models.Model):
 
     def to_dcat(self):
         result = dict()
+        result['@type'] = 'dcat:Catalog'
         result['dct:title'] = self.title
         result['dct:description'] = self.description
         result['dct:publisher'] = self.publisher.to_dcat()
+        if self.homepage:
+            result['foaf:homepage'] = {'@type': 'foaf:Document', 'foaf:Document': self.homepage}
         return result
 
     def __str__(self):

--- a/dcat/models.py
+++ b/dcat/models.py
@@ -85,6 +85,9 @@ class Catalog(models.Model):
         result['dct:publisher'] = self.publisher.to_dcat()
         if self.homepage:
             result['foaf:homepage'] = {'@type': 'foaf:Document', 'foaf:Document': self.homepage}
+
+        result['dcat:dataset'] = [dataset.to_dcat() for dataset in self.dataset_set.all()]
+
         return result
 
     def __str__(self):
@@ -112,6 +115,7 @@ class Dataset(models.Model):
     catalog = models.ForeignKey("Catalog", on_delete=models.CASCADE)
 
     # Recommended properties
+    # TODO: description is mandatory
     description = models.TextField(
         blank=True, help_text="A free-text account of the Dataset."
     )
@@ -141,6 +145,13 @@ class Dataset(models.Model):
         blank=True,
         help_text="A web page that provides access to the Dataset, its Distributions and/or additional information. It is intended to point to a landing page at the original data provider, not to a page on a site of a third party, such as an aggregator.",
     )
+
+    def to_dcat(self):
+        result = dict()
+        result['dct:title'] = self.title
+        if self.description:
+            result['dct:description'] = self.description
+        return result
 
     def __str__(self):
         return self.title

--- a/runtests.py
+++ b/runtests.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+import os
+import sys
+
+import django
+from django.conf import settings
+from django.test.utils import get_runner
+
+if __name__ == "__main__":
+    os.environ["DJANGO_SETTINGS_MODULE"] = "tests.test_settings"
+    django.setup()
+    TestRunner = get_runner(settings)
+    test_runner = TestRunner()
+    failures = test_runner.run_tests(["tests"])
+    sys.exit(bool(failures))

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,3 +29,10 @@ packages = find:
 python_requires = >=3.10
 install_requires =
     Django >= 5.0
+
+[flake8]
+extend-ignore = E501
+exclude =
+    .git,
+    .venv,
+    __pycache__

--- a/tests/test_dcat_feed.py
+++ b/tests/test_dcat_feed.py
@@ -4,7 +4,7 @@ from dcat.models import Agent, Catalog, Dataset
 # Create your tests here.
 
 
-class DCATExportTestCase(TestCase):
+class DCATSerializationJSONLDTestCase(TestCase):
 
     def setUp(self):
         publisher = Agent.objects.create(
@@ -28,20 +28,20 @@ class DCATExportTestCase(TestCase):
             catalog=catalog,
         )
 
-    def test_agent_to_dcat(self):
+    def test_agent_to_jsonld(self):
         publisher = Agent.objects.first()
-        result = publisher.to_dcat()
+        result = publisher.to_jsonld()
         self.assertEqual(result['@type'], publisher.type)
         self.assertEqual(result['foaf:name'], publisher.name)
 
-    def test_catalog_to_dcat(self):
+    def test_catalog_to_jsonld(self):
         catalog = Catalog.objects.first()
-        result = catalog.to_dcat()
+        result = catalog.to_jsonld()
 
         self.assertEqual(result['@type'], 'dcat:Catalog')
         self.assertEqual(result['dct:title'], catalog.title)
         self.assertEqual(result['dct:description'], catalog.description)
-        self.assertEqual(result['dct:publisher'], catalog.publisher.to_dcat())
+        self.assertEqual(result['dct:publisher'], catalog.publisher.to_jsonld())
         self.assertEqual(result['foaf:homepage'], {'@type': 'foaf:Document', 'foaf:Document': catalog.homepage})
         self.assertEqual(
             result['dcat:dataset'],

--- a/tests/test_dcat_feed.py
+++ b/tests/test_dcat_feed.py
@@ -1,5 +1,6 @@
 from django.test import TestCase
-from dcat.models import Agent, Catalog
+from dcat.models import Agent, Catalog, Dataset
+
 # Create your tests here.
 
 
@@ -10,11 +11,21 @@ class DCATExportTestCase(TestCase):
             name='Food and Agriculture Organization of the United Nations',
             type='foaf:Agent'
         )
-        Catalog.objects.create(
+        catalog = Catalog.objects.create(
             title='FAO Data in Emergencies',
             description='A testing catalog based on true data.',
             publisher=publisher,
             homepage='https://data-in-emergencies.fao.org'
+        )
+
+        Dataset.objects.create(
+            title='Colombia - Household Questionnaire - Round 3',
+            description='Household questionarie',
+            catalog=catalog,
+        )
+        Dataset.objects.create(
+            title='Afghanistan - Household Questionnaire - Round 6',
+            catalog=catalog,
         )
 
     def test_agent_to_dcat(self):
@@ -32,3 +43,10 @@ class DCATExportTestCase(TestCase):
         self.assertEqual(result['dct:description'], catalog.description)
         self.assertEqual(result['dct:publisher'], catalog.publisher.to_dcat())
         self.assertEqual(result['foaf:homepage'], {'@type': 'foaf:Document', 'foaf:Document': catalog.homepage})
+        self.assertEqual(
+            result['dcat:dataset'],
+            [
+                {'dct:title': 'Colombia - Household Questionnaire - Round 3', 'dct:description': 'Household questionarie'},
+                {'dct:title': 'Afghanistan - Household Questionnaire - Round 6'}
+            ]
+        )

--- a/tests/test_dcat_feed.py
+++ b/tests/test_dcat_feed.py
@@ -13,7 +13,8 @@ class DCATExportTestCase(TestCase):
         Catalog.objects.create(
             title='FAO Data in Emergencies',
             description='A testing catalog based on true data.',
-            publisher=publisher
+            publisher=publisher,
+            homepage='https://data-in-emergencies.fao.org'
         )
 
     def test_agent_to_dcat(self):
@@ -26,6 +27,8 @@ class DCATExportTestCase(TestCase):
         catalog = Catalog.objects.first()
         result = catalog.to_dcat()
 
+        self.assertEqual(result['@type'], 'dcat:Catalog')
         self.assertEqual(result['dct:title'], catalog.title)
         self.assertEqual(result['dct:description'], catalog.description)
         self.assertEqual(result['dct:publisher'], catalog.publisher.to_dcat())
+        self.assertEqual(result['foaf:homepage'], {'@type': 'foaf:Document', 'foaf:Document': catalog.homepage})

--- a/tests/test_dcat_feed.py
+++ b/tests/test_dcat_feed.py
@@ -1,0 +1,31 @@
+from django.test import TestCase
+from dcat.models import Agent, Catalog
+# Create your tests here.
+
+
+class DCATExportTestCase(TestCase):
+
+    def setUp(self):
+        publisher = Agent.objects.create(
+            name='Food and Agriculture Organization of the United Nations',
+            type='foaf:Agent'
+        )
+        Catalog.objects.create(
+            title='FAO Data in Emergencies',
+            description='A testing catalog based on true data.',
+            publisher=publisher
+        )
+
+    def test_agent_to_dcat(self):
+        publisher = Agent.objects.first()
+        result = publisher.to_dcat()
+        self.assertEqual(result['@type'], publisher.type)
+        self.assertEqual(result['foaf:name'], publisher.name)
+
+    def test_catalog_to_dcat(self):
+        catalog = Catalog.objects.first()
+        result = catalog.to_dcat()
+
+        self.assertEqual(result['dct:title'], catalog.title)
+        self.assertEqual(result['dct:description'], catalog.description)
+        self.assertEqual(result['dct:publisher'], catalog.publisher.to_dcat())

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,14 @@
+import os
+
+SECRET_KEY = "fake-key"
+
+INSTALLED_APPS = [
+    "dcat",
+]
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.sqlite3",
+        "NAME": os.environ.get("DB_NAME", "db.sqlite3"),
+    }
+}


### PR DESCRIPTION
This PR starts implementing a serialization function `to_jsonld` in all models.

This PR is being inspired by: https://data-in-emergencies.fao.org/api/feed/dcat-ap/2.1.1.json